### PR TITLE
Fix for caret placement after multiple lines with different text indents are folded

### DIFF
--- a/lib/codemirror.js
+++ b/lib/codemirror.js
@@ -1218,25 +1218,30 @@ window.CodeMirror = (function() {
     if (lineIsHidden(cm.doc, lineObj)) {
       var notHidden = -1,
           line = pos.line,
-          lo = null;
+          lo = null,
+          ea = emptyArray(lineObj.text.length),
+          opre = lineContent(cm, lineObj, ea),
+          currentIndent = parseFloat(opre.style.textIndent, 10),
+          currentLeftPadding = parseFloat(opre.style.paddingLeft, 10),
+          actualIndent = currentIndent,
+          actualLeftPadding = currentIndent;
 
       while((lo = getLine(cm.doc, line)) && lineIsHidden(cm, lo)) {
         line --;
       }
 
-      var indent = 0;
       if (line >= 0) {
-        var ea = emptyArray(lo.text.length),
-            pre = lineContent(cm, lo, ea);
+        var pre = lineContent(cm, lo, emptyArray(lo.text.length));
 
-        indent = parseFloat(pre.style.textIndent,10);
+        actualIndent = parseFloat(pre.style.textIndent,10);
+        actualLeftPadding = parseFloat(pre.style.paddingLeft, 10);
       }
 
-      if (indent !== 0) {
+      if ((currentIndent + currentLeftPadding) !== (actualIndent + actualLeftPadding)) {
         for (var i = 0; i < measurement.length; i++) {
           if (measurement[i]) {
-            measurement[i].left += indent;
-            measurement[i].right += indent;
+            measurement[i].left += -currentIndent + actualIndent - currentLeftPadding + actualLeftPadding;
+            measurement[i].right += -currentIndent + actualIndent - currentLeftPadding + actualLeftPadding;
           }
         }
       }


### PR DESCRIPTION
The problem was I wasn't taking into consideration the left and right padding (still going to ignore the right padding till we see a use case where that affects it).

works for most of my cases now, which are:
# one

two

one
# two
###### one

two
- nothing
  - nothing
    bionic

one last that I discovered was if you make the last case folded into:
- nothing
  - no[...]nic
